### PR TITLE
Read the iRODS config from Vault.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -18,10 +18,10 @@
   :uberjar-name "porklock-standalone.jar"
   :plugins [[test2junit "1.2.2"]]
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/tools.cli "0.3.1"]
+                 [org.clojure/tools.cli "0.3.5"]
                  [org.clojure/tools.logging "0.3.1"]
-                 [commons-io/commons-io "2.4"]
+                 [commons-io/commons-io "2.5"]
                  [slingshot "0.12.2"]
                  [org.cyverse/clj-jargon "2.8.3"]
-                 [org.cyverse/clojure-commons "2.8.0"]
+                 [org.cyverse/clojure-commons "2.8.3"]
                  [org.cyverse/common-cli "2.8.1"]])

--- a/project.clj
+++ b/project.clj
@@ -24,4 +24,5 @@
                  [slingshot "0.12.2"]
                  [org.cyverse/clj-jargon "2.8.3"]
                  [org.cyverse/clojure-commons "2.8.3"]
-                 [org.cyverse/common-cli "2.8.1"]])
+                 [org.cyverse/common-cli "2.8.1"]
+                 [amperity/vault-clj "0.4.0"]])

--- a/src/porklock/commands.clj
+++ b/src/porklock/commands.clj
@@ -17,8 +17,8 @@
 (def porkprint (partial println "[porklock] "))
 
 (defn init-jargon
-  [cfg-path]
-  (load-config-from-file cfg-path)
+  [cfg-string]
+  (load-config-from-string cfg-string)
   (jg/init (irods-host)
            (irods-port)
            (irods-user)

--- a/src/porklock/config.clj
+++ b/src/porklock/config.clj
@@ -58,10 +58,22 @@
   (when-not (cc/validate-config configs config-valid)
     (throw+ {:error_code ce/ERR_CONFIG_INVALID})))
 
+(defn- set-props-from-string
+  [config]
+  (dosync
+    (ref-set props
+            (doto (java.util.Properties.)
+                  (.load (java.io.StringReader. config))))))
+
+(defn load-config-from-string
+  [config]
+  (set-props-from-string config)
+  (cc/log-config props :filters [#"irods-user"])
+  (validate-config))
+
 (defn load-config-from-file
   "Loads the configuration settings from a file."
   [config-path]
   (cc/load-config-from-file (cf/dirname config-path) (cf/basename config-path) props)
   (cc/log-config props :filters [#"irods-user"])
   (validate-config))
-

--- a/src/porklock/core.clj
+++ b/src/porklock/core.clj
@@ -6,6 +6,7 @@
   (:require [clojure.tools.cli :as cli]
             [clojure.string :as string]
             [common-cli.version :as version]
+            [porklock.vault :as pork-vault]
             [clojure-commons.error-codes
              :as error
              :refer [ERR_DOES_NOT_EXIST ERR_NOT_A_FILE ERR_NOT_A_FOLDER ERR_NOT_WRITEABLE]])
@@ -36,11 +37,6 @@
        "--destination"
        "The local directory that the files will be downloaded into."
        :default "."]
-
-      ["-c"
-       "--config"
-       "Tells porklock where to read its configuration."
-       :default nil]
 
       ["-m"
        "--meta"
@@ -93,11 +89,6 @@
        "The destination directory in iRODS."
        :default nil]
 
-      ["-c"
-       "--config"
-       "Tells porklock where to read its configuration."
-       :default nil]
-
       ["-m"
        "--meta"
        "Comma-delimited ATTR-VALUE-UNIT"
@@ -112,6 +103,24 @@
        "--help"
        "Prints this help."
        :flag true])))
+
+(defn- vault-settings
+  "Reads the VAULT_TOKEN, VAULT_ADDR, and JOB_UUID environment variables and
+   places them into the options map as :vault-token, :vault-addr, and :job-uuid,
+   respectively. This function does not check if the settings are empty before
+   adding them to the map, that should be done elsewhere."
+  [options]
+  (assoc options :vault-token (System/getenv "VAULT_TOKEN")
+                 :vault-addr  (System/getenv "VAULT_ADDR")
+                 :job-uuid    (System/getenv "JOB_UUID")))
+
+(defn- read-vault-config
+  "Reads the iRODS config from Vault and puts it into the options map as a
+   string value with a key of :config."
+  [options]
+  (assoc options :config (pork-vault/irods-config (:vault-addr options)
+                                                  (:vault-token options)
+                                                  (:job-uuid options))))
 
 (def usage "Usage: porklock get|put [options]")
 
@@ -162,7 +171,8 @@
     (let [cmd          (command args)
           version-info (version/version-info "org.cyverse" "porklock")
           cmd-args     (rest args)
-          [options remnants banner] (settings cmd cmd-args)]
+          [options remnants banner] (settings cmd cmd-args)
+          options      (vault-settings options)]
 
       (when (= cmd "--version")
         (println version-info)
@@ -184,12 +194,12 @@
       (case cmd
         "get"   (do
                   (validate-get options)
-                  (iget-command options)
+                  (iget-command (read-vault-config options))
                   (System/exit 0))
 
         "put"   (do
                   (validate-put options)
-                  (iput-command options)
+                  (iput-command (read-vault-config options))
                   (System/exit 0))
 
         (do

--- a/src/porklock/core.clj
+++ b/src/porklock/core.clj
@@ -28,6 +28,11 @@
        "The user the tool should run as."
        :default nil]
 
+      ["-z"
+       "--debug-config"
+       "The path to a local iRODS config. Used for debugging purposes only."
+       :default nil]
+
       ["-s"
        "--source"
        "The directory in iRODS contains files to be downloaded."
@@ -57,6 +62,11 @@
       ["-u"
        "--user"
        "The user the tool should run as."
+       :default nil]
+
+      ["-z"
+       "--debug-config"
+       "The path to a local iRODS config. Used for debugging purposes only."
        :default nil]
 
       ["-e"
@@ -118,9 +128,11 @@
   "Reads the iRODS config from Vault and puts it into the options map as a
    string value with a key of :config."
   [options]
-  (assoc options :config (pork-vault/irods-config (:vault-addr options)
-                                                  (:vault-token options)
-                                                  (:job-uuid options))))
+  (if (:debug-config options)
+    (assoc options :config (slurp (:debug-config options)))
+    (assoc options :config (pork-vault/irods-config (:vault-addr options)
+                                                    (:vault-token options)
+                                                    (:job-uuid options)))))
 
 (def usage "Usage: porklock get|put [options]")
 

--- a/src/porklock/validation.clj
+++ b/src/porklock/validation.clj
@@ -45,9 +45,17 @@
     (throw+ {:error_code ERR_PATH_NOT_ABSOLUTE
              :path (:destination options)}))
 
-  (if-not (:config options)
+  (if-not (:vault-addr options)
     (throw+ {:error_code ERR_MISSING_OPTION
-             :option "--config"}))
+             :option "VAULT_ADDR environment variable"}))
+
+  (if-not (:vault-token options)
+    (throw+ {:error_code ERR_MISSING_OPTION
+             :option "VAULT_TOKEN environment variable"}))
+
+  (if-not (:job-uuid options)
+    (throw+ {:error_code ERR_MISSING_OPTION
+             :option "JOB_UUID environment variable"}))
 
   (println "Files to upload: ")
     (pprint (files-to-transfer options))
@@ -89,9 +97,17 @@
     (throw+ {:error_code ERR_MISSING_OPTION
              :option "--destination"}))
 
-  (if-not (:config options)
+  (if-not (:vault-addr options)
     (throw+ {:error_code ERR_MISSING_OPTION
-             :option "--config"}))
+             :option "VAULT_ADDR environment variable"}))
+
+  (if-not (:vault-token options)
+    (throw+ {:error_code ERR_MISSING_OPTION
+             :option "VAULT_TOKEN environment variable"}))
+
+  (if-not (:job-uuid options)
+    (throw+ {:error_code ERR_MISSING_OPTION
+             :option "JOB_UUID environment variable"}))
 
   (let [paths-to-check (flatten [(:destination options)
                                  (:config options)])]

--- a/src/porklock/validation.clj
+++ b/src/porklock/validation.clj
@@ -61,8 +61,7 @@
     (pprint (files-to-transfer options))
     (println " ")
 
-  (let [paths-to-check (flatten [(files-to-transfer options)
-                                 (:config options)])]
+  (let [paths-to-check (flatten [(files-to-transfer options)])]
 
     (println "Paths to check: ")
     (pprint paths-to-check)
@@ -109,8 +108,7 @@
     (throw+ {:error_code ERR_MISSING_OPTION
              :option "JOB_UUID environment variable"}))
 
-  (let [paths-to-check (flatten [(:destination options)
-                                 (:config options)])]
+  (let [paths-to-check (flatten [(:destination options)])]
     (doseq [p paths-to-check]
       (if (not (ft/exists? p))
         (throw+ {:error_code ERR_DOES_NOT_EXIST

--- a/src/porklock/validation.clj
+++ b/src/porklock/validation.clj
@@ -45,17 +45,18 @@
     (throw+ {:error_code ERR_PATH_NOT_ABSOLUTE
              :path (:destination options)}))
 
-  (if-not (:vault-addr options)
-    (throw+ {:error_code ERR_MISSING_OPTION
-             :option "VAULT_ADDR environment variable"}))
+  (when-not (:debug-config options)
+    (if-not (:vault-addr options)
+      (throw+ {:error_code ERR_MISSING_OPTION
+               :option "VAULT_ADDR environment variable"}))
 
-  (if-not (:vault-token options)
-    (throw+ {:error_code ERR_MISSING_OPTION
-             :option "VAULT_TOKEN environment variable"}))
+    (if-not (:vault-token options)
+      (throw+ {:error_code ERR_MISSING_OPTION
+               :option "VAULT_TOKEN environment variable"}))
 
-  (if-not (:job-uuid options)
-    (throw+ {:error_code ERR_MISSING_OPTION
-             :option "JOB_UUID environment variable"}))
+    (if-not (:job-uuid options)
+      (throw+ {:error_code ERR_MISSING_OPTION
+               :option "JOB_UUID environment variable"})))
 
   (println "Files to upload: ")
     (pprint (files-to-transfer options))
@@ -96,17 +97,18 @@
     (throw+ {:error_code ERR_MISSING_OPTION
              :option "--destination"}))
 
-  (if-not (:vault-addr options)
-    (throw+ {:error_code ERR_MISSING_OPTION
-             :option "VAULT_ADDR environment variable"}))
+  (when-not (:debug-config options)
+    (if-not (:vault-addr options)
+      (throw+ {:error_code ERR_MISSING_OPTION
+               :option "VAULT_ADDR environment variable"}))
 
-  (if-not (:vault-token options)
-    (throw+ {:error_code ERR_MISSING_OPTION
-             :option "VAULT_TOKEN environment variable"}))
+    (if-not (:vault-token options)
+      (throw+ {:error_code ERR_MISSING_OPTION
+               :option "VAULT_TOKEN environment variable"}))
 
-  (if-not (:job-uuid options)
-    (throw+ {:error_code ERR_MISSING_OPTION
-             :option "JOB_UUID environment variable"}))
+    (if-not (:job-uuid options)
+      (throw+ {:error_code ERR_MISSING_OPTION
+               :option "JOB_UUID environment variable"})))
 
   (let [paths-to-check (flatten [(:destination options)])]
     (doseq [p paths-to-check]

--- a/src/porklock/vault.clj
+++ b/src/porklock/vault.clj
@@ -1,0 +1,31 @@
+(ns porklock.vault
+  (:use [vault.client.http])
+  (:require [vault.core :as vault])
+  (:import [java.util Base64]))
+
+(defn client
+  "Creates and returns a Vault client that will connects to the provided Vault
+   API URI and is already authenticated with the given token."
+  [uri token]
+  (-> (vault/new-client uri)
+      (vault/authenticate! :token token)))
+
+(defn- read-config
+  "Reads the iRODS config from vault using cl as the Vault client. The uuid is
+   used to construct the path to the config inside Vault. This should return the
+   iRODS config as a base64 encoded string."
+  [cl uuid]
+  (:config (vault/read-secret cl (str "cubbyhole/" uuid))))
+
+(defn- decode
+  "Decodes the base64 encoded config string."
+  [config]
+  (String. (.decode (Base64/getDecoder) config)))
+
+(defn irods-config
+  "The full workflow for reading the irods-config from Vault. Creates a Vault
+   client, reads the config, and base64 decodes it, returning the result."
+  [uri token uuid]
+  (-> (client uri token)
+      (read-config uuid)
+      (decode)))

--- a/src/porklock/vault.clj
+++ b/src/porklock/vault.clj
@@ -4,7 +4,7 @@
   (:import [java.util Base64]))
 
 (defn client
-  "Creates and returns a Vault client that will connects to the provided Vault
+  "Creates and returns a Vault client that will connect to the provided Vault
    API URI and is already authenticated with the given token."
   [uri token]
   (-> (vault/new-client uri)


### PR DESCRIPTION
Porklock needs to be able to pull the iRODS configuration settings out of Vault.

Support for reading the **VAULT_ADDR**, **VAULT_TOKEN**, and **JOB_UUID** environment variables has been added. **JOB_UUID** corresponds to the invocation ID for now.

The `--config` command-line flag was removed.

A `--debug-config` command-line flag was added, which allows porklock to read the config from the command-line. It's been changed from `--config` to force errors to occur if an automated process hasn't been updated yet.

The new `porklock.vault` namespace contains the code that interacts with Vault.


