### PR TITLE
CORE-9100 Update --exclude option as a single path to an exclusion list.

### DIFF
--- a/src/porklock/core.clj
+++ b/src/porklock/core.clj
@@ -9,8 +9,7 @@
             [porklock.vault :as pork-vault]
             [clojure-commons.error-codes
              :as error
-             :refer [ERR_DOES_NOT_EXIST ERR_NOT_A_FILE ERR_NOT_A_FOLDER ERR_NOT_WRITEABLE]])
-  (:import [org.apache.log4j Logger Level]))
+             :refer [ERR_DOES_NOT_EXIST ERR_NOT_A_FILE ERR_NOT_A_FOLDER ERR_NOT_WRITEABLE]]))
 
 
 (defn- fmeta-split
@@ -71,13 +70,13 @@
 
       ["-e"
        "--exclude"
-       "List of files to be excluded from uploads."
+       "The path to a file containing a list of paths to be excluded from uploads."
        :default ""]
 
       ["-x"
        "--exclude-delimiter"
        "Delimiter for the list of files to be excluded from uploads"
-       :default ","]
+       :default "\n"]
 
       ["-i"
        "--include"

--- a/test/porklock/pathing_test.clj
+++ b/test/porklock/pathing_test.clj
@@ -1,0 +1,19 @@
+(ns porklock.pathing-test
+  (:use [clojure.test])
+  (:require [porklock.pathing :as pathing]))
+
+(def exclusions-file-path "test/resources/exclusions.list")
+
+(deftest exclude-files-from-dir-test
+  (testing "exclude-files-from-dir"
+    (let [exclude-paths (set (pathing/exclude-files-from-dir {:exclude exclusions-file-path :exclude-delimiter "\n"}))]
+      (is (contains? exclude-paths "test1.txt"))
+      (is (contains? exclude-paths "test2.txt"))
+      (is (contains? exclude-paths "test3.txt")))))
+
+(deftest exclude-files-test
+  (testing "exclude-files"
+   (let [exclude-paths (set (pathing/exclude-files {:exclude exclusions-file-path :exclude-delimiter "\n"}))]
+     (is (contains? exclude-paths "test1.txt"))
+     (is (contains? exclude-paths "test2.txt"))
+     (is (contains? exclude-paths "test3.txt")))))

--- a/test/resources/exclusions.list
+++ b/test/resources/exclusions.list
@@ -1,0 +1,3 @@
+test1.txt
+test2.txt
+test3.txt


### PR DESCRIPTION
This PR will update the `--exclude` option as a single path to an exclusion list, so that the paths to exclude from output upload will now be parsed from the file at the given path.

This will prevent "argument list too long" errors if a job has a large number of inputs, or inputs with very long names. The list of inputs to exclude from uploading in the results output folder can now be added to the `--exclude` path list file.