### PR TITLE
CORE-9191 Update `get` command with `--source-list` option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ GIT_COMMIT
 VERSION
 build.xml
 test2junit
+.idea

--- a/src/porklock/commands.clj
+++ b/src/porklock/commands.clj
@@ -244,13 +244,13 @@
 
 (defn- parse-source-list
   "Returns a list of paths read from the the given `source-list` path list file, or nil if the file does not exist.
-   Assumes the first line of the path list is a header-line, and discards it from the results."
+   Removes lines beginning with a hash character: #."
   [source-list]
   (when (ft/exists? (str source-list))
     (->> source-list
          slurp
          string/split-lines
-         rest)))
+         (remove #(string/starts-with? % "#")))))
 
 (defn apply-input-metadata
   [cm user fpath meta]

--- a/src/porklock/core.clj
+++ b/src/porklock/core.clj
@@ -34,7 +34,12 @@
 
       ["-s"
        "--source"
-       "The directory in iRODS contains files to be downloaded."
+       "A path in iRODS to be downloaded."
+       :default nil]
+
+      ["-l"
+       "--source-list"
+       "A path to a local Path-List file, containing a list of paths in iRODS to be downloaded."
        :default nil]
 
       ["-d"

--- a/src/porklock/validation.clj
+++ b/src/porklock/validation.clj
@@ -89,9 +89,9 @@
   (if-not (usable? (:user options))
     (throw+ {:error_code ERR_ACCESS_DENIED}))
 
-  (if-not (:source options)
+  (if-not (or (:source options) (:source-list options))
     (throw+ {:error_code ERR_MISSING_OPTION
-             :option "--source"}))
+             :option "--source or --source-list"}))
 
   (if-not (:destination options)
     (throw+ {:error_code ERR_MISSING_OPTION


### PR DESCRIPTION
This PR will update the `get` command with a new `--source-list` option, and update `porklock.commands/iget-command` to download all paths parsed from the path-list file given in this new option.

Now porklock requires either a `--source` or `--source-list` option, or both (the iRODS path given in `--source` will be appended to the paths parsed from the `--source-list` file).