### PR TITLE
Use a sorted map in order to upload files in a predictable order

### DIFF
--- a/src/porklock/pathing.clj
+++ b/src/porklock/pathing.clj
@@ -95,13 +95,14 @@
    (ft/path-join ddir (string/replace transfer-file (re-pattern sdir) ""))))
 
 (defn relative-dest-paths
-  "Constructs a list of absolute destination paths based on the
-   input and the given source directory."
+  "Constructs a sorted map between source paths and absolute destination paths
+   based on the input and the given source directory."
   [transfer-files source-dir dest-dir]
 
   (let [sdir (ft/add-trailing-slash source-dir)]
     (apply
       merge
+      (sorted-map)
       (map
         #(if (str-contains? %1 sdir)
            {%1 (fix-path %1 sdir dest-dir)})


### PR DESCRIPTION
This doesn't really matter much, per se, but I've seen at least one user confused at why they had such a strange mix of files when the upload process got interrupted, and it might make things easier for us debugging sometimes. The performance should be about the same, as far as I can tell -- I guess insertions to the sorted map might be minorly slower but iteration will be minorly faster, and it's probably all splitting hairs anyway compared to, e.g. JVM startup.