### PR TITLE
Upgrade to openjdk 17 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM clojure:lein-alpine
+FROM clojure:openjdk-17-lein-alpine
 
 WORKDIR /usr/src/app
 
 RUN apk add --no-cache git
 
-RUN ln -s "/usr/bin/java" "/bin/porklock"
+RUN ln -s "/opt/openjdk-17/bin/java" "/bin/porklock"
 
 COPY project.clj /usr/src/app/
 RUN lein deps


### PR DESCRIPTION
So uh, `clojure:lein-alpine` is from May 2019, because of weird JDK stuff. There's a new alpine image for OpenJDK 17, though. I tested downloading a file and it worked.