### PR TITLE
DS-611: use unproxied admin account for setting AVUs.

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,1 @@
+{:ignore [:unresolved-symbol]}

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ test2junit
 .idea
 .tramp_history
 .eastwood
+.clj-kondo/.cache

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ build.xml
 test2junit
 .idea
 .tramp_history
+.eastwood

--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,8 @@
   :main ^:skip-aot porklock.core
   :profiles {:uberjar {:aot :all}}
   :uberjar-name "porklock-standalone.jar"
-  :plugins [[test2junit "1.2.2"]]
+  :plugins [[test2junit "1.2.2"]
+            [jonase/eastwood "1.4.0"]]
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.cli "0.3.5"]
                  [org.clojure/tools.logging "0.3.1"]

--- a/src/porklock/commands.clj
+++ b/src/porklock/commands.clj
@@ -192,7 +192,7 @@
     (let [dest       (ft/path-join (:destination options) "logs")
           exclusions (set (exclude-files-from-dir (merge options {:source (script-loc)})))]
       (porkprint "Exclusions:\n" exclusions)
-      (doseq [fileobj (file-seq (clojure.java.io/file (script-loc)))]
+      (doseq [^java.io.File fileobj (file-seq (clojure.java.io/file (script-loc)))]
         (let [src       (.getAbsolutePath fileobj)
               dest-path (ft/path-join dest (ft/basename src))]
           (try+
@@ -233,7 +233,7 @@
       (when-not (:skip-parent-meta options)
         (porkprint "Applying metadata to" (:destination options))
         (apply-metadata admin-cm (:destination options) (:meta options))
-        (doseq [fileobj (file-seq (info/file cm (:destination options)))]
+        (doseq [^java.io.File fileobj (file-seq (info/file cm (:destination options)))]
           (apply-metadata admin-cm (.getAbsolutePath fileobj) (:meta options))))
 
       ;;; Transfer files from the NFS mount point into the logs
@@ -258,7 +258,7 @@
   (if-not (info/is-dir? cm fpath)
     (if (perms/owns? cm user fpath)
       (apply-metadata cm fpath meta))
-    (doseq [f (file-seq (info/file cm fpath))]
+    (doseq [^java.io.File f (file-seq (info/file cm fpath))]
       (let [abs-path (.getAbsolutePath f)]
         (if (perms/owns? cm user abs-path)
           (apply-metadata cm abs-path meta))))))

--- a/src/porklock/commands.clj
+++ b/src/porklock/commands.clj
@@ -1,6 +1,4 @@
 (ns porklock.commands
-  (:use [porklock.pathing]
-        [porklock.config])
   (:require [clj-jargon.init :as jg]
             [clj-jargon.item-info :as info]
             [clj-jargon.item-ops :as ops]
@@ -9,23 +7,24 @@
             [clojure-commons.file-utils :as ft]
             [clojure.java.io :as io]
             [clojure.string :as string]
+            [porklock.config :as cfg]
+            [porklock.pathing :as pathing]
             [slingshot.slingshot :refer [throw+ try+]])
-  (:import [java.io File]                                            ; needed for cursive type navigation
-           [org.irods.jargon.core.exception DuplicateDataException]
+  (:import [org.irods.jargon.core.exception DuplicateDataException]
            [org.irods.jargon.core.transfer TransferStatus]))         ; needed for cursive type navigation
 
 (def porkprint (partial println "[porklock] "))
 
 (defn init-jargon
   [cfg-path]
-  (load-config-from-file cfg-path)
-  (jg/init (irods-host)
-           (irods-port)
-           (irods-user)
-           (irods-pass)
-           (irods-home)
-           (irods-zone)
-           (irods-resc)))
+  (cfg/load-config-from-file cfg-path)
+  (jg/init (cfg/irods-host)
+           (cfg/irods-port)
+           (cfg/irods-user)
+           (cfg/irods-pass)
+           (cfg/irods-home)
+           (cfg/irods-zone)
+           (cfg/irods-resc)))
 
 (defn retry
   "Attempt calling (func) with args a maximum of 'times' times if an error occurs.
@@ -94,7 +93,7 @@
   "Callback function for the overallStatus function for a TransferCallbackListener."
   [^TransferStatus transfer-status]
   (let [exc (.getTransferException transfer-status)]
-    (if-not (nil? exc)
+    (when-not (nil? exc)
       (throw exc))))
 
 (defn iput-status-cb
@@ -144,7 +143,7 @@
 
 (defn- relative-destination-paths
   [options]
-  (relative-dest-paths (files-to-transfer options)
+  (pathing/relative-dest-paths (pathing/files-to-transfer options)
                        (ft/abs-path (:source options))
                        (:destination options)))
 
@@ -171,7 +170,7 @@
 
           (try+
            (if (ft/dir? src)
-             (if-not (info/exists? cm dest)
+             (when-not (info/exists? cm dest)
               (ops/mkdir cm dest))
              (retry 10 ops/iput cm src dest tcl))
 
@@ -188,9 +187,9 @@
 
 (defn- upload-nfs-files
   [admin-cm cm options]
-  (if (and (System/getenv "SCRIPT_LOCATION") (not (:skip-parent-meta options)))
+  (when (and (System/getenv "SCRIPT_LOCATION") (not (:skip-parent-meta options)))
     (let [dest       (ft/path-join (:destination options) "logs")
-          exclusions (set (exclude-files-from-dir (merge options {:source (script-loc)})))]
+          exclusions (set (pathing/exclude-files-from-dir (merge options {:source (script-loc)})))]
       (porkprint "Exclusions:\n" exclusions)
       (doseq [^java.io.File fileobj (file-seq (clojure.java.io/file (script-loc)))]
         (let [src       (.getAbsolutePath fileobj)
@@ -240,7 +239,7 @@
       ;;; directory of the destination
       (upload-nfs-files admin-cm cm options)
 
-      (if @error?
+      (when @error?
         (throw (Exception. "An error occurred tranferring files into iRODS. Please check the above logs for more information."))))))
 
 (defn- parse-source-list
@@ -256,11 +255,11 @@
 (defn apply-input-metadata
   [cm user fpath meta]
   (if-not (info/is-dir? cm fpath)
-    (if (perms/owns? cm user fpath)
+    (when (perms/owns? cm user fpath)
       (apply-metadata cm fpath meta))
     (doseq [^java.io.File f (file-seq (info/file cm fpath))]
       (let [abs-path (.getAbsolutePath f)]
-        (if (perms/owns? cm user abs-path)
+        (when (perms/owns? cm user abs-path)
           (apply-metadata cm abs-path meta))))))
 
 (defn iget-command

--- a/src/porklock/config.clj
+++ b/src/porklock/config.clj
@@ -1,9 +1,8 @@
 (ns porklock.config
-  (:use [slingshot.slingshot :only [try+ throw+]])
   (:require [clojure-commons.config :as cc]
             [clojure-commons.error-codes :as ce]
             [clojure-commons.file-utils :as cf]
-            [clojure.tools.logging :as log]))
+            [slingshot.slingshot :refer [throw+]]))
 
 (def ^:private props
   "A ref for storing the configuration properties."

--- a/src/porklock/core.clj
+++ b/src/porklock/core.clj
@@ -1,14 +1,14 @@
 (ns porklock.core
   (:gen-class)
-  (:use [porklock.commands]
-        [porklock.validation]
-        [slingshot.slingshot :only [try+ throw+]])
   (:require [clojure.tools.cli :as cli]
             [clojure.string :as string]
             [common-cli.version :as version]
             [clojure-commons.error-codes
              :as error
-             :refer [ERR_DOES_NOT_EXIST ERR_NOT_A_FILE ERR_NOT_A_FOLDER ERR_NOT_WRITEABLE]]))
+             :refer [ERR_DOES_NOT_EXIST ERR_NOT_A_FILE ERR_NOT_A_FOLDER ERR_NOT_WRITEABLE]]
+            [porklock.commands :as commands]
+            [porklock.validation :as validation]
+            [slingshot.slingshot :refer [try+]]))
 
 
 (defn- fmeta-split
@@ -187,13 +187,13 @@
 
       (case cmd
         "get"   (do
-                  (validate-get options)
-                  (iget-command options)
+                  (validation/validate-get options)
+                  (commands/iget-command options)
                   (System/exit 0))
 
         "put"   (do
-                  (validate-put options)
-                  (iput-command options)
+                  (validation/validate-put options)
+                  (commands/iput-command options)
                   (System/exit 0))
 
         (do

--- a/src/porklock/fileops.clj
+++ b/src/porklock/fileops.clj
@@ -9,7 +9,7 @@
    present under 'parent'."
   [parent]
   (map
-    #(ft/normalize-path (.getAbsolutePath %))
+    #(ft/normalize-path (.getAbsolutePath ^java.io.File %))
     (FileUtils/listFilesAndDirs
       (file parent)
       TrueFileFilter/INSTANCE

--- a/src/porklock/fileops.clj
+++ b/src/porklock/fileops.clj
@@ -1,6 +1,6 @@
 (ns porklock.fileops
-  (:use [clojure.java.io :only (file)])
-  (:require [clojure-commons.file-utils :as ft])
+  (:require [clojure.java.io :refer [file]]
+            [clojure-commons.file-utils :as ft])
   (:import [org.apache.commons.io FileUtils]
            [org.apache.commons.io.filefilter TrueFileFilter DirectoryFileFilter]))
 

--- a/src/porklock/pathing.clj
+++ b/src/porklock/pathing.clj
@@ -34,7 +34,7 @@
   "Splits up the exclude option and turns the result into paths in the source dir."
   [{source :source exclude-file :exclude delimiter :exclude-delimiter}]
   (mapv
-   #(if-not (.startsWith % "/")
+   #(if-not (string/starts-with? % "/")
      (ft/path-join source %)
      %)
    (paths-to-exclude exclude-file delimiter)))
@@ -59,7 +59,7 @@
    Otherwise, only that exact path matches."
   [path filter-path]
   (if (ft/dir? filter-path)
-    (.startsWith path filter-path)
+    (string/starts-with? path filter-path)
     (= path filter-path)))
 
 (defn should-not-exclude?
@@ -85,7 +85,7 @@
 
 (defn- str-contains?
   [s match]
-  (if (not= (.indexOf s match) -1)
+  (if (not= (string/index-of s match) -1)
     true
     false))
 

--- a/src/porklock/validation.clj
+++ b/src/porklock/validation.clj
@@ -1,16 +1,16 @@
 (ns porklock.validation
-  (:use [porklock.pathing]
-        [clojure.pprint]
-        [slingshot.slingshot :only [try+ throw+]]
-        [clojure-commons.error-codes])
-  (:require [clojure-commons.file-utils :as ft]))
+  (:require [clojure.pprint :refer [pprint]]
+            [clojure-commons.error-codes :as ce]
+            [clojure-commons.file-utils :as ft]
+            [porklock.pathing :as pathing]
+            [slingshot.slingshot :refer [throw+]]))
 
 (def ERR_MISSING_OPTION "ERR_MISSING_OPTION")
 (def ERR_PATH_NOT_ABSOLUTE "ERR_PATH_NOT_ABSOLUTE")
 (def ERR_ACCESS_DENIED "ERR_ACCESS_DENIED")
 
 (defn usable?
-  [user]
+  [_]
   true)
 
 (defn validate-put
@@ -22,45 +22,45 @@
    of the .irods/* files must exist, and the paths
    to the executable must exist."
   [options]
-  (if-not (:user options)
+  (when-not (:user options)
     (throw+ {:error_code ERR_MISSING_OPTION
              :option "--user"}))
 
-  (if-not (usable? (:user options))
+  (when-not (usable? (:user options))
     (throw+ {:error_code ERR_ACCESS_DENIED}))
 
-  (if-not (:source options)
+  (when-not (:source options)
     (throw+ {:error_code ERR_MISSING_OPTION
              :option "--source"}))
 
-  (if-not (:destination options)
+  (when-not (:destination options)
     (throw+ {:error_code ERR_MISSING_OPTION
              :option "--destination"}))
 
-  (if-not (ft/dir? (:source options))
-      (throw+ {:error_code ERR_NOT_A_FOLDER
+  (when-not (ft/dir? (:source options))
+      (throw+ {:error_code ce/ERR_NOT_A_FOLDER
                :path (:source options)}))
 
-  (if-not (ft/abs-path? (:destination options))
+  (when-not (ft/abs-path? (:destination options))
     (throw+ {:error_code ERR_PATH_NOT_ABSOLUTE
              :path (:destination options)}))
 
-  (if-not (:config options)
+  (when-not (:config options)
     (throw+ {:error_code ERR_MISSING_OPTION
              :option "--config"}))
 
   (println "Files to upload: ")
-    (pprint (files-to-transfer options))
+    (pprint (pathing/files-to-transfer options))
     (println " ")
 
-  (let [paths-to-check (flatten [(files-to-transfer options)
+  (let [paths-to-check (flatten [(pathing/files-to-transfer options)
                                  (:config options)])]
 
     (println "Paths to check: ")
     (pprint paths-to-check)
     (doseq [p paths-to-check]
-      (if (not (ft/exists? p))
-        (throw+ {:error_code ERR_DOES_NOT_EXIST
+      (when-not (ft/exists? p)
+        (throw+ {:error_code ce/ERR_DOES_NOT_EXIST
                  :path p})))))
 
 (defn validate-get
@@ -74,32 +74,32 @@
    Additionally:
      * Destination must be a directory."
   [options]
-  (if-not (:user options)
+  (when-not (:user options)
     (throw+ {:error_code ERR_MISSING_OPTION
              :option "--user"}))
 
-  (if-not (usable? (:user options))
+  (when-not (usable? (:user options))
     (throw+ {:error_code ERR_ACCESS_DENIED}))
 
-  (if-not (or (:source options) (:source-list options))
+  (when-not (or (:source options) (:source-list options))
     (throw+ {:error_code ERR_MISSING_OPTION
              :option "--source or --source-list"}))
 
-  (if-not (:destination options)
+  (when-not (:destination options)
     (throw+ {:error_code ERR_MISSING_OPTION
              :option "--destination"}))
 
-  (if-not (:config options)
+  (when-not (:config options)
     (throw+ {:error_code ERR_MISSING_OPTION
              :option "--config"}))
 
   (let [paths-to-check (flatten [(:destination options)
                                  (:config options)])]
     (doseq [p paths-to-check]
-      (if (not (ft/exists? p))
-        (throw+ {:error_code ERR_DOES_NOT_EXIST
+      (when-not (ft/exists? p)
+        (throw+ {:error_code ce/ERR_DOES_NOT_EXIST
                  :path p})))
 
-    (if-not (ft/dir? (:destination options))
-      (throw+ {:error_code ERR_NOT_A_FOLDER
+    (when-not (ft/dir? (:destination options))
+      (throw+ {:error_code ce/ERR_NOT_A_FOLDER
                :path (:destination options)}))))


### PR DESCRIPTION
The primary purpose of this change is to use an unproxied admin account when setting AVUs on files and folders. This change makes the assumption that all AVUs that are set by `porklock` will be admin AVUs. If this is not or may not always be the case then it will be necessary to revisit this change.

While I was modifying the code, I also fixed several lint warnings that were produced by `jonase/eastwood` and `clj-kondo`.
