### PR TITLE
CORE-1964: omit the current working directory from the list of paths …

### DIFF
--- a/src/porklock/pathing.clj
+++ b/src/porklock/pathing.clj
@@ -72,7 +72,10 @@
   "Constructs a list of files that shouldn't be filtered out by the list of
    excluded files."
   [source-dir excludes]
-  (filter #(should-not-exclude? excludes %) (fileops/files-and-dirs source-dir)))
+  (let [working-dir (System/getProperty "user.dir")]
+    (->> (fileops/files-and-dirs source-dir)
+         (remove (partial = working-dir))
+         (filter (partial should-not-exclude? excludes)))))
 
 (defn files-to-transfer
   "Constructs a list of the files that need to be transferred."


### PR DESCRIPTION
…to upload

The current working directory was being included in the list of files to upload, which was causing an error. Excluding the current working directory works because all of the contents of the current working directory are included in the unfiltered list of files to upload anyway.