### PR TITLE
CORE-2160: dependency updates.

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,11 +4,12 @@ on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+u[0-9]+"
       - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
 
 jobs:
   call-workflow-passing-data:
-    uses: cyverse-de/github-workflows/.github/workflows/docker-build.yml@v0.1.4
+    uses: cyverse-de/github-workflows/.github/workflows/docker-build.yml@v0.3.1
     with:
       build-prerelease: ${{ contains(github.ref_name, '-rc') }}
     secrets:

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ test2junit
 .tramp_history
 .eastwood
 .clj-kondo/.cache
+.lsp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM clojure:openjdk-17-lein-alpine
+FROM FROM clojure:temurin-25-lein-trixie
 
 WORKDIR /usr/src/app
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(use '[clojure.java.shell :only (sh)])
+(require '[clojure.java.shell :refer (sh)])
 (require '[clojure.string :as string])
 
 (defn git-ref
@@ -19,27 +19,11 @@
   :plugins [[jonase/eastwood "1.4.0"]
             [lein-ancient "0.7.0"]
             [test2junit "1.2.2"]]
-  :dependencies [[org.clojure/clojure "1.11.1"]
-                 [org.clojure/tools.cli "1.0.219"]
-                 [org.clojure/tools.logging "1.2.4"]
-                 [commons-io/commons-io "2.14.0"]
+  :dependencies [[org.clojure/clojure "1.12.5"]
+                 [org.clojure/tools.cli "1.4.256"]
+                 [org.clojure/tools.logging "1.3.1"]
+                 [commons-io/commons-io "2.22.0"]
                  [slingshot "0.12.2"]
-                 [org.cyverse/clj-jargon "3.1.0"]
-                 [org.cyverse/clojure-commons "3.0.7"]
-                 [org.cyverse/common-cli "2.8.1"]
-                 [org.irods.jargon/jargon-core "4.1.10.0-RELEASE"
-                  :exclusions [[org.jglobus/JGlobus-Core]
-                               [org.slf4j/slf4j-api]
-                               [org.slf4j/slf4j-log4j12]]]
-                 [org.irods.jargon/jargon-data-utils "4.1.10.0-RELEASE"
-                  :exclusions [[org.slf4j/slf4j-api]
-                               [org.slf4j/slf4j-log4j12]]]
-                 [org.irods.jargon/jargon-ticket "4.1.10.0-RELEASE"
-                  :exclusions [[org.slf4j/slf4j-api]
-                               [org.slf4j/slf4j-log4j12]]]]
-  :repositories [["cyverse-de"
-                  {:url "https://raw.github.com/cyverse-de/mvn/master/releases"}]
-                 ["dice.repository"
-                  {:url "https://raw.github.com/DICE-UNC/DICE-Maven/master/releases"}]
-                 ["renci-snapshot.repository"
-                  {:url "https://ci-dev.renci.org/nexus/content/repositories/renci-snapshot/"}]])
+                 [org.cyverse/clj-jargon "3.1.5"]
+                 [org.cyverse/clojure-commons "3.0.12"]
+                 [org.cyverse/common-cli "2.8.2"]])


### PR DESCRIPTION
The primary reason for this change is to update dependencies in order to obtain the latest bug fixes in `clj-jargon`. I don't think that this utility is used anymore, but I thought I would update it anyway since it's not archived.